### PR TITLE
set user attribute prior-login based on old value of last-login

### DIFF
--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -10,6 +10,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.UserModel;
 
+import java.util.Map;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -34,6 +35,12 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
 
             if (user != null) {
                 log.info("Updating last login status for user: " + event.getUserId());
+
+                Map userAttrs = user.getAttributes();
+                if (userAttrs.containsKey("last-login")) {
+                    String userLastLogin = userAttrs.get("last-login").toString();
+                    user.setSingleAttribute("prior-login", userLastLogin.substring(1, userLastLogin.length()-1));
+                }
 
                 // Use current server time for login event
                 LocalDateTime loginTime = LocalDateTime.now();

--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -10,6 +10,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.UserModel;
 
+import java.util.List;
 import java.util.Map;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -36,10 +37,10 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
             if (user != null) {
                 log.info("Updating last login status for user: " + event.getUserId());
 
-                Map userAttrs = user.getAttributes();
+                Map<String, List<String>> userAttrs = user.getAttributes();
                 if (userAttrs.containsKey("last-login")) {
-                    String userLastLogin = userAttrs.get("last-login").toString();
-                    user.setSingleAttribute("prior-login", userLastLogin.substring(1, userLastLogin.length()-1));
+                    String userLastLogin = userAttrs.get("last-login").get(0);
+                    user.setSingleAttribute("prior-login", userLastLogin);
                 }
 
                 // Use current server time for login event

--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -39,9 +39,9 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
 
                 Map<String, List<String>> userAttrs = user.getAttributes();
                 if (userAttrs.containsKey("last-login")) {
-                    String userLastLogin = userAttrs.get("last-login").get(0);
+                    List<String> userLastLogin = userAttrs.get("last-login");
                     if (userLastLogin != null && !userLastLogin.isEmpty()) {
-                        user.setSingleAttribute("prior-login", userLastLogin);
+                        user.setSingleAttribute("prior-login", userLastLogin.get(0);
                     }
                 }
 

--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -40,7 +40,9 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
                 Map<String, List<String>> userAttrs = user.getAttributes();
                 if (userAttrs.containsKey("last-login")) {
                     String userLastLogin = userAttrs.get("last-login").get(0);
-                    user.setSingleAttribute("prior-login", userLastLogin);
+                    if (userLastLogin != null && !userLastLogin.isEmpty()) {
+                        user.setSingleAttribute("prior-login", userLastLogin);
+                    }
                 }
 
                 // Use current server time for login event


### PR DESCRIPTION
This change adds a second user attribute prior-login which is set to the last value of last-login.

It's used to present a classic last login message to the user after login.

Please forgive me using the .substring() method to strip [] of List string serialization. I'm a Java illiterate. Thus I couldn't get a more elegant solution to work.