### PR TITLE
store UTC time-stamp strings to avoid time-zone issues

### DIFF
--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -12,7 +12,8 @@ import org.keycloak.models.UserModel;
 
 import java.util.List;
 import java.util.Map;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public class LastLoginEventListenerProvider implements EventListenerProvider {
@@ -46,7 +47,7 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
                 }
 
                 // Use current server time for login event
-                LocalDateTime loginTime = LocalDateTime.now();
+                OffsetDateTime loginTime = OffsetDateTime.now(ZoneOffset.UTC);
                 String loginTimeS = DateTimeFormatter.ISO_DATE_TIME.format(loginTime);
                 user.setSingleAttribute("last-login", loginTimeS);
             }


### PR DESCRIPTION
Note that the local time in Keycloak depends on system settings and can vary in containers, normal OS deployment etc.

Because consumers of last-login and prior-login attributes probably have to deal with users in different time zones the timestamp string values shall contain time-zone information.

=> the easiest approach is to always use UTC and let consumers deal with it for local date-time representation.