### PR TITLE
Update KC Version, update readme, get rid of deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Sets a last login attribute on the user model when they login.
 
 This is based on the templates provided by [zonaut](https://github.com/zonaut/keycloak-extensions).
 
-Building can be done via `mvn clean install`. Please take a look at the aforementioned repository for a far more detailed introduction.
+Building can be done via `gradlew build`, which will locate a `.jar` in the the `build/libs`. Copy/Move it in your keycloak `providers` folders. Add `last_login` to the event listeners under "Events"->"Config" in the Keycloak UI. Please take a look at the aforementioned repository for a far more detailed introduction.
 
 This repository will most likely not keep up with the keycloak release cycle. You have been warned.

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ version = '0.0.1-SNAPSHOT'
 description = 'last-login-event-listener'
 
 ext {
-    keycloakVersion = "16.1.1"
+    keycloakVersion = "17.0.0"
 }
 
 

--- a/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
+++ b/src/main/java/de/scimeda/keycloak/events/logging/LastLoginEventListenerProvider.java
@@ -33,7 +33,7 @@ public class LastLoginEventListenerProvider implements EventListenerProvider {
         // log.infof("## NEW %s EVENT", event.getType());
         if (EventType.LOGIN.equals(event.getType())) {
             RealmModel realm = this.model.getRealm(event.getRealmId());
-            UserModel user = this.session.users().getUserById(event.getUserId(), realm);
+            UserModel user = this.session.users().getUserById(realm, event.getUserId());
 
             if (user != null) {
                 log.info("Updating last login status for user: " + event.getUserId());


### PR DESCRIPTION
I updated the KC Version, added some more information to the readme (for Java/Gradle noobs) and changed the order of the attributes to get rid of the deprecation warning (https://www.keycloak.org/docs-api/13.0/javadocs/org/keycloak/storage/user/UserLookupProvider.html)